### PR TITLE
Include a linux release for lima-and-qemu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   GO111MODULE: on
 
 jobs:
-  release:
+  macos-build:
     runs-on: macos-10.15
     timeout-minutes: 20
     steps:
@@ -37,10 +37,87 @@ jobs:
     - name: Create lima-and-qemu tarball
       run: |
         ./src/lima/hack/lima-and-qemu.pl
-        sha512sum src/lima/lima-and-qemu.tar.gz > src/lima/lima-and-qemu.tar.gz.sha512sum
+        mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.MacOS.tar.gz
+        sha512sum src/lima/lima-and-qemu.MacOS.tar.gz > src/lima/lima-and-qemu.MacOS.tar.gz.sha512sum
+    - name: Upload MacOS build
+      uses: actions/upload-artifact@v2
+      with:
+        name: lima-and-qemu.MacOS
+        path: ./src/lima/lima-and-qemu.MacOS*
+        if-no-files-found: error
+
+  linux-build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 20
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        submodules: recursive
+        persist-credentials: false
+    - name: Lima install on Linux
+      run: |
+        dest="$(pwd)/lima-and-qemu"
+        echo "dest=${dest}" >> $GITHUB_ENV
+        make -C src/lima
+        make -C src/lima install DESTDIR="${dest}" PREFIX="/usr"
+    - name: Install Linux dependecies
+      # QEMU:      required by Lima itself
+      env:
+        QEMU_SHA256SUM: eebc089db3414bbeedf1e464beda0a7515aad30f73261abc246c9b27503a3c96
+        QEMU_VERSION: 6.1.0
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq ninja-build
+        df -h
+        wget https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz -O qemu.tar.xz
+        [ "${QEMU_SHA256SUM}" = "$(sha256sum qemu.tar.xz | head -c 64)" ] || exit 1
+        mkdir qemu
+        tar xaf qemu.tar.xz -C qemu --strip-components=1
+        mkdir qemu/build
+        cd qemu/build
+        ../configure --prefix="/usr" --disable-user --enable-kvm --target-list=x86_64-softmmu 
+        make -j$(nproc)
+        make install DESTDIR=${{ env.dest }}
+    - name: Create Linux lima-and-qemu tarball
+      run: |
+        src/appdir-lima-and-qemu.sh "${{ env.dest }}/usr"
+        mv lima-and-qemu.tar.gz lima-and-qemu.Linux.tar.gz
+        sha512sum lima-and-qemu.Linux.tar.gz > lima-and-qemu.Linux.tar.gz.sha512sum
+    - name: Upload Linux build
+      uses: actions/upload-artifact@v2
+      with:
+        name: lima-and-qemu.Linux
+        path: lima-and-qemu.Linux*
+        if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+    - macos-build
+    - linux-build
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Download Linux build
+      uses: actions/download-artifact@v2
+      with:
+        name: lima-and-qemu.Linux
+        path: build
+    - name: Download MacOS build
+      uses: actions/download-artifact@v2
+      with:
+        name: lima-and-qemu.MacOS
+        path: build
     - name: "Create release"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         tag="${GITHUB_REF##*/}"
-        hub release create -a src/lima/lima-and-qemu.tar.gz -a src/lima/lima-and-qemu.tar.gz.sha512sum -F <(echo ${tag}) --draft "${tag}"
+        hub release create -a build/lima-and-qemu.Linux.tar.gz -a build/lima-and-qemu.Linux.tar.gz.sha512sum -a build/lima-and-qemu.MacOS.tar.gz -a build/lima-and-qemu.MacOS.tar.gz.sha512sum -m "${tag}" --draft "${tag}"

--- a/src/appdir-lima-and-qemu.sh
+++ b/src/appdir-lima-and-qemu.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# This is a helper script to build an appDir structure to
+# include lima and qemu as part of an AppImage binary.
+# The binaries build should happen in the oldest available Ubuntu LTS
+
+function error {
+  >&2 echo "$@"
+  exit 1
+}
+
+function keepListedFiles {
+  local dir=$1
+  local list=$2
+
+  [ -d "${dir}" ] || error "${dir} is not a directory"
+  
+  for it in $(ls ${dir}); do
+    if [[ "${list}" =~ \ ${it}\  ]]; then
+      continue
+    fi
+    [ -n "${it}" ] && rm -rf "${dir}/${it}"
+  done
+}
+
+set -e
+
+[ -n "${1}" ] || error "One argument to the built app dir is required"
+[ -d "${1}" ] || error "Directory ${1} doesn't exist"
+
+appDir=$1
+dist="lima-and-qemu"
+
+# Inspired on linuxdeployqt https://github.com/probonopd/linuxdeployqt/blob/master/tools/linuxdeployqt/excludelist.h
+# Linuxdeployqt is a tool created by probonopd, the AppImage creator
+excludeLibs=" libz.so.1 "
+excludeLibs+="libgio-2.0.so.0 "
+excludeLibs+="libgobject-2.0.so.0 "
+excludeLibs+="libglib-2.0.so.0 "
+excludeLibs+="libutil.so.1 "
+excludeLibs+="libm.so.6 "
+excludeLibs+="libgcc_s.so.1 "
+excludeLibs+="libpthread.so.0 "
+excludeLibs+="libc.so.6 "
+excludeLibs+="libresolv.so.2 "
+excludeLibs+="libdl.so.2 "
+excludeLibs+="librt.so.1 "
+excludeLibs+="libuuid.so.1 "
+
+firmwareOfInterest=" bios-256k.bin edk2-x86_64-code.fd efi-virtio.rom kvmvapic.bin vgabios-virtio.bin "
+executablesOfInterest=" qemu-system-x86_64 qemu-img limactl "
+
+mkdir -p "${appDir}/lib"
+
+linkedLibs=$(ldd "${appDir}/bin/qemu-system-x86_64" | grep " => /" | cut -d" " -f3)
+linkedLibs+=$(ldd "${appDir}/bin/qemu-img" | grep " => /" | cut -d" " -f3)
+for lib in $(echo ${linkedLibs} | sort | uniq ); do
+  if [[ "${excludeLibs}" =~ \ $(basename ${lib})\  ]]; then
+    continue
+  fi
+  cp "${lib}" "${appDir}/lib"
+done
+
+# strip docs
+rm -rf "${appDir}/share/doc"
+
+# remove lima agent for aarch64
+rm "${appDir}/share/lima/lima-guestagent.Linux-aarch64" 
+
+# remove qemu icons, includes, etc.
+# We could fine tune the firmaware files
+rm -rf "${appDir}/include"
+rm -rf "${appDir}/libexec"
+rm -rf "${appDir}/var"
+rm -rf "${appDir}/share/applications"
+rm -rf "${appDir}/share/icons"
+
+# keep only relevant firmware
+keepListedFiles "${appDir}/share/qemu" "${firmwareOfInterest}"
+
+# keep only relevant executables
+keepListedFiles "${appDir}/bin" "${executablesOfInterest}"
+
+tar caf "${dist}.tar.gz" -C "${appDir}" .


### PR DESCRIPTION
This PR adds a new job for building lima-and-qemu on linux.
Under linux in compiles latest qemu release and collects the linked
libraries according to common AppImage practices.

Signed-off-by: David Cassany <dcassany@suse.com>