### PR TITLE
Ensure files in the archive are user-writable.

### DIFF
--- a/bin/lima-and-qemu.pl
+++ b/bin/lima-and-qemu.pl
@@ -134,6 +134,10 @@ if (-f "$opt_vde/bin/vde_vmnet") {
     }
 }
 
+# Ensure all files are writable by the owner; this is required for Squirrel.Mac
+# to remove the quarantine xattr when applying updates.
+system("chmod -R u+w /tmp/$dist")
+
 unlink("$repo_root/$dist.tar.gz");
 system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist $files");
 


### PR DESCRIPTION
Squirrel.Mac tries to remove the quarantine xattr on all files when it applies the update; this fails if any file in the update is not user-writable.  This ensures that we package all files (for eventual distribution in Rancher Desktop) as user-writable, so that it can successfully remove the extended attribute.

Note that `-execdir` didn't work here for some reason; I needed to use `-exec` for things to work correctly.