### PR TITLE
Remove libgmodule to fix problem with AppImages on Fedora 35

### DIFF
--- a/bin/appdir-lima-and-qemu.sh
+++ b/bin/appdir-lima-and-qemu.sh
@@ -47,6 +47,7 @@ excludeLibs+="libdl.so.2 "
 excludeLibs+="librt.so.1 "
 excludeLibs+="libuuid.so.1 "
 excludeLibs+="libdl.so.2 "
+excludeLibs+="libgmodule-2.0.so.0 "
 
 firmwareOfInterest=" bios-256k.bin edk2-x86_64-code.fd efi-virtio.rom kvmvapic.bin vgabios-virtio.bin "
 executablesOfInterest=" qemu-system-x86_64 qemu-img limactl "


### PR DESCRIPTION
Normally, the bundle this project produces includes the `libgmodule` .so. This .so makes it into the AppImage that is eventually built. However, as detailed in issue https://github.com/rancher-sandbox/rancher-desktop/issues/1269, having this .so in the AppImage leads to a conflict when running it on Fedora 35.

This PR makes it so that libgmodule is not included in the bundle. I've tested the AppImage without libgmodule on the following distros without issue:

- Ubuntu 18.04
- openSUSE Leap 15.3
- Rocky Linux 8.5
- Mint 20.2
- Fedora 35